### PR TITLE
Change implementation of drag/drop in order to support touch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "place-value-add-and-subtract",
+  "name": "place-value-add-subtract-2",
   "version": "1.0.0",
   "description": "",
   "keywords": [],

--- a/public/index.html
+++ b/public/index.html
@@ -1,17 +1,19 @@
 <!DOCTYPE html>
 <html lang="en">
-
-<head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-	<meta name="theme-color" content="#000000">
-	<!--
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <meta name="theme-color" content="#000000" />
+    <!--
       manifest.json provides metadata used when your web app is added to the
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
     -->
-	<link rel="manifest" href="%PUBLIC_URL%/manifest.json">
-	<link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
-	<!--
+    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
+    <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -20,15 +22,15 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-	<title>React App</title>
-</head>
+    <title>React App</title>
+  </head>
 
-<body>
-	<noscript>
-		You need to enable JavaScript to run this app.
-	</noscript>
-	<div id="root"></div>
-	<!--
+  <body>
+    <noscript>
+      You need to enable JavaScript to run this app.
+    </noscript>
+    <div id="root"></div>
+    <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -38,6 +40,5 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-</body>
-
+  </body>
 </html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,9 @@ import {
 } from "./appModel";
 
 import { NumberRepresentation } from "./NumberRepresentation";
+import { usePointerTracker } from "./DragDrop/hooks/usePointerTracker";
+import { composePointerEventHandlers } from "./DragDrop/composePointerEventHandlers";
+import { usePointerEnterExitTracker } from "./DragDrop/hooks/usePointerEnterExitTracker";
 
 function addText({ lhs, rhs }: Question): string {
   return `Add ${rhs} (bottom number) to ${lhs} (top number) so that the top number becomes ${lhs} + ${rhs}.`;
@@ -37,12 +40,17 @@ export default function App() {
     generateInitialState
   );
 
+  const dragEvents = composePointerEventHandlers(
+    usePointerTracker(),
+    usePointerEnterExitTracker()
+  );
+
   const handleOnClick = React.useCallback(() => {
     dispatch(createActionRandomQuestion());
   }, []);
 
   return (
-    <div className="App">
+    <div className="App" {...dragEvents}>
       <h1>Place value</h1>
       <h2>{questionText(state.question)}</h2>
       <div style={{ position: "relative" }}>

--- a/src/Brick.tsx
+++ b/src/Brick.tsx
@@ -1,5 +1,4 @@
-import "./styles.css";
-import * as React from "react";
+import { useDraggable } from "./DragDrop/hooks/useDraggable";
 
 export interface BrickProps {
   hide?: boolean;
@@ -15,29 +14,17 @@ export function brickFactory(brickClass: string) {
     onBeginDrag,
     onEndDrag
   }: BrickProps) {
-    const [isDragging, setIsDragging] = React.useState(false);
-
-    const handleDragStart = React.useCallback(
-      (ev: React.DragEvent<HTMLDivElement>) => {
-        onBeginDrag?.();
-        requestAnimationFrame(() => setIsDragging(true));
-        ev.stopPropagation();
-      },
-      [onBeginDrag]
-    );
-
-    const handleDragEnd = React.useCallback(() => {
-      setIsDragging(false);
-      onEndDrag?.();
-    }, [onEndDrag]);
+    const { dragStyle, dragEvents } = useDraggable({
+      canDrag: !hide && !ghost,
+      onBeginDrag,
+      onEndDrag
+    });
 
     return (
       <div
         className={`${brickClass} ${hide ? "Hide" : ghost ? "Ghost" : " "}`}
-        style={{ visibility: isDragging ? "hidden" : undefined }}
-        draggable={!hide && !ghost}
-        onDragStart={handleDragStart}
-        onDragEnd={handleDragEnd}
+        style={dragStyle}
+        {...dragEvents}
       />
     );
   }

--- a/src/DragDrop/composePointerEventHandlers.ts
+++ b/src/DragDrop/composePointerEventHandlers.ts
@@ -1,0 +1,34 @@
+import { PointerEvents, PointerEventKeys } from "./pointerEventTypes";
+
+export function composePointerEventHandlers<T = Element>(
+  handlers1: Partial<PointerEvents<T>>,
+  handlers2: Partial<PointerEvents<T>>
+): Partial<PointerEvents<T>> {
+  const pointerEventHandlers: Partial<PointerEvents<T>> = {
+    ...handlers1,
+    ...handlers2
+  };
+
+  ([
+    "onPointerDown",
+    "onPointerMove",
+    "onPointerUp",
+    "onPointerCancel",
+    "onPointerOver",
+    "onPointerOut",
+    "onPointerEnter",
+    "onPointerLeave"
+  ] as PointerEventKeys[]).forEach((prop) => {
+    const evtHandler1 = handlers1[prop];
+    const evtHandler2 = handlers2[prop];
+
+    if (evtHandler1 && evtHandler2) {
+      pointerEventHandlers[prop] = (evt) => {
+        evtHandler1(evt);
+        evtHandler2(evt);
+      };
+    }
+  });
+
+  return pointerEventHandlers;
+}

--- a/src/DragDrop/dragDropController.ts
+++ b/src/DragDrop/dragDropController.ts
@@ -1,0 +1,127 @@
+/**
+ * DragDropController class. Manages the lifecycle of drag/drop.
+ *
+ * Participants:
+ *
+ * 1. Draggable object - signals when it receives a pointer-down event
+ * 2. Drop target - signals when a pointer enters/leaves its area
+ */
+
+/** Two-dimensional displacement */
+export interface Offset {
+  readonly dx: number;
+  readonly dy: number;
+}
+
+/** Two-dimensional position */
+export interface Position {
+  readonly left: number;
+  readonly top: number;
+}
+
+/**
+ * The DragDropController uses this interface to tell the draggable
+ * object when to begin/end drag, and how to displace the object as
+ * the user moves the pointer
+ */
+export interface Draggable {
+  beginDrag(): void;
+  endDrag(): void;
+  updateDrag(offset: Offset): void;
+}
+
+export interface DropTarget {
+  activateDrop(): void;
+  deactivateDrop(): void;
+  performDrop(): void;
+}
+
+/**
+ * A drop target signals to the drop controller when a pointer
+ * enters/leaves it
+ */
+export interface DropController {
+  enterDrop(me: DropTarget): void;
+  leaveDrop(me: DropTarget): void;
+}
+
+/**
+ * A draggable object signals to the DragController when it
+ * receives a pointer down event. The DragDropController will
+ * notify the Draggable object when to begin/end drag, and how
+ * to displace the object
+ */
+export interface DragController {
+  dragMe(me: Draggable): void;
+}
+
+/**
+ * Top level control signals pointer events. The DragDropController
+ * uses this information to determine the lifecycle of a drag-and-drop
+ * operation.
+ */
+export interface PointerTracker {
+  pointerDown(position: Position): void;
+  pointerMove(position: Position): void;
+  pointerUp(): void;
+}
+
+/**
+ * Controller for Drag/Drop handling
+ */
+export class DragDropController
+  implements DragController, DropController, PointerTracker {
+  private currentDraggable: Draggable | null = null;
+  private currentDropTarget: DropTarget | null = null;
+  private dragStartLocation: Position | null = null;
+
+  //#region DragController
+  public dragMe(me: Draggable) {
+    if (this.currentDraggable === null) {
+      this.currentDraggable = me;
+      me.beginDrag();
+    }
+  }
+  //#endregion DragController
+
+  //#region DropController
+  public enterDrop(me: DropTarget) {
+    if (this.currentDraggable !== null && this.currentDropTarget === null) {
+      this.currentDropTarget = me;
+      me.activateDrop();
+    }
+  }
+
+  public leaveDrop(me: DropTarget) {}
+  //#endregion DropController
+
+  //#region PointerTracker
+  public pointerDown(position: Position) {
+    this.dragStartLocation = position;
+  }
+
+  public pointerMove(position: Position) {
+    if (this.dragStartLocation && this.currentDraggable) {
+      this.currentDraggable.updateDrag({
+        dx: position.left - this.dragStartLocation.left,
+        dy: position.top - this.dragStartLocation.top
+      });
+    }
+  }
+
+  public pointerUp() {
+    console.assert(this.dragStartLocation !== null);
+
+    if (this.currentDropTarget !== null) {
+      this.currentDropTarget.performDrop();
+
+      this.currentDropTarget = null;
+    }
+
+    if (this.currentDraggable !== null) {
+      this.currentDraggable.endDrag();
+      this.currentDraggable = null;
+    }
+  }
+  //#endregion PointerTracker
+}

--- a/src/DragDrop/dragDropControllerContext.ts
+++ b/src/DragDrop/dragDropControllerContext.ts
@@ -1,0 +1,6 @@
+import { createContext } from "react";
+import { DragDropController } from "./dragDropController";
+
+export const DragDropControllerContext = createContext<DragDropController>(
+  new DragDropController()
+);

--- a/src/DragDrop/hooks/pointerEventTypes.ts
+++ b/src/DragDrop/hooks/pointerEventTypes.ts
@@ -1,0 +1,12 @@
+export interface PointerEvents<T = Element> {
+  onPointerDown: React.PointerEventHandler<T>;
+  onPointerMove: React.PointerEventHandler<T>;
+  onPointerUp: React.PointerEventHandler<T>;
+  onPointerCancel: React.PointerEventHandler<T>;
+  onPointerOver: React.PointerEventHandler<T>;
+  onPointerOut: React.PointerEventHandler<T>;
+  onPointerEnter: React.PointerEventHandler<T>;
+  onPointerLeave: React.PointerEventHandler<T>;
+}
+
+type PointerEventKeys = keyof PointerEvents;

--- a/src/DragDrop/hooks/useDraggable.ts
+++ b/src/DragDrop/hooks/useDraggable.ts
@@ -1,0 +1,85 @@
+import * as React from "react";
+import { DragController, Draggable, Offset } from "../dragDropController";
+import { DragDropControllerContext } from "../dragDropControllerContext";
+export interface DragEvents<T = Element> {
+  onPointerDown: React.PointerEventHandler<T>;
+}
+
+export interface UseDraggableResult<T = Element> {
+  dragStyle: React.CSSProperties;
+  dragEvents: DragEvents<T>;
+}
+
+export interface UseDraggableParams {
+  canDrag: boolean;
+  onBeginDrag?: () => void;
+  onEndDrag?: () => void;
+}
+
+export function useDraggable<T = Element>(
+  { canDrag, onBeginDrag, onEndDrag }: UseDraggableParams = { canDrag: true }
+): UseDraggableResult<T> {
+  // Drag controller from context
+  const dragController: DragController = React.useContext(
+    DragDropControllerContext
+  );
+
+  // Track drag state
+  const [offset, setOffset] = React.useState<Offset | null>(null);
+
+  const refDraggable = React.useRef<Draggable | null>(null);
+
+  refDraggable.current = {
+    beginDrag() {
+      setOffset({ dx: 0, dy: 0 });
+      onBeginDrag?.();
+    },
+
+    endDrag() {
+      setOffset(null);
+      onEndDrag?.();
+    },
+
+    updateDrag(offset: Offset) {
+      setOffset(offset);
+    }
+  };
+
+  // Draggable callback interface (pointer must be stable across re-renders)
+  const draggableStableProxy: Draggable = React.useMemo(
+    () => ({
+      beginDrag() {
+        refDraggable.current?.beginDrag();
+      },
+      endDrag() {
+        refDraggable.current?.endDrag();
+      },
+      updateDrag(offset) {
+        refDraggable.current?.updateDrag(offset);
+      }
+    }),
+    []
+  );
+
+  const onPointerDown: React.PointerEventHandler<T> = (evt) => {
+    if (evt.isPrimary && canDrag) {
+      dragController.dragMe(draggableStableProxy);
+      evt.preventDefault();
+    }
+  };
+
+  const dragStyle: React.CSSProperties =
+    offset === null
+      ? {}
+      : {
+          opacity: 0.5,
+          transform: `translate(${offset.dx}px,${offset.dy}px)`
+        };
+
+  return {
+    dragStyle,
+    dragEvents: {
+      onPointerDown
+    }
+  };
+}

--- a/src/DragDrop/hooks/useDropTarget.ts
+++ b/src/DragDrop/hooks/useDropTarget.ts
@@ -1,0 +1,84 @@
+import * as React from "react";
+
+import { Rect, Surface } from "../pointerEnterExitTracker";
+import { DropController, DropTarget } from "../dragDropController";
+
+import { DragDropControllerContext } from "../dragDropControllerContext";
+import { PointerEnterExitTrackerContext } from "../pointerEnterExitTrackerContext";
+
+export interface UseDropTargetParams<T> {
+  refElement: React.RefObject<T>;
+  canDrop: boolean;
+  onDropTargetEnter: () => void;
+  onDropTargetLeave: () => void;
+  onDrop: () => void;
+}
+
+const emptyRect: Rect = {
+  left: 0,
+  top: 0,
+  width: 0,
+  height: 0
+};
+
+class DropTargetImpl<T extends Element> implements DropTarget, Surface {
+  private params?: UseDropTargetParams<T>;
+  private dropController?: DropController;
+
+  public updateState(
+    params: UseDropTargetParams<T>,
+    dropController: DropController
+  ) {
+    this.params = params;
+    this.dropController = dropController;
+  }
+
+  public activateDrop() {
+    this.params?.onDropTargetEnter();
+  }
+
+  public deactivateDrop() {
+    this.params?.onDropTargetLeave();
+  }
+
+  public performDrop() {
+    this.params?.onDrop();
+  }
+
+  public getBoundingRect() {
+    return (
+      this.params?.refElement.current?.getBoundingClientRect() ?? emptyRect
+    );
+  }
+
+  public enter() {
+    this.dropController?.enterDrop(this);
+  }
+
+  public exit() {
+    this.dropController?.leaveDrop(this);
+  }
+}
+
+export function useDropTarget<T extends Element = Element>(
+  params: UseDropTargetParams<T>
+): void {
+  // DropController from context
+  const dropController: DropController = React.useContext(
+    DragDropControllerContext
+  );
+
+  const pointerEnterExitTracker = React.useContext(
+    PointerEnterExitTrackerContext
+  );
+
+  const instance = React.useMemo(() => new DropTargetImpl(), []);
+  instance.updateState(params, dropController);
+
+  React.useEffect(() => {
+    if (params.canDrop && instance) {
+      pointerEnterExitTracker.addSurface(instance);
+      return () => pointerEnterExitTracker.removeSurface(instance);
+    }
+  }, [instance, pointerEnterExitTracker, params.canDrop]);
+}

--- a/src/DragDrop/hooks/useLogPointerEvents.ts
+++ b/src/DragDrop/hooks/useLogPointerEvents.ts
@@ -1,0 +1,24 @@
+import { PointerEvents, PointerEventKeys } from "../pointerEventTypes";
+
+export function useLogPointerEvents<T = Element>(
+  targetName: string,
+  canDrag: boolean
+): Partial<PointerEvents<T>> {
+  const dragDropEvents: Partial<PointerEvents<T>> = {};
+  ([
+    "onPointerDown",
+    "onPointerMove",
+    "onPointerUp",
+    "onPointerCancel",
+    "onPointerOver",
+    "onPointerOut",
+    "onPointerEnter",
+    "onPointerLeave"
+  ] as PointerEventKeys[]).forEach((prop) => {
+    dragDropEvents[prop] = (evt) => {
+      console.log(`${targetName} - ${prop}`);
+    };
+  });
+
+  return dragDropEvents;
+}

--- a/src/DragDrop/hooks/usePointerEnterExitTracker.ts
+++ b/src/DragDrop/hooks/usePointerEnterExitTracker.ts
@@ -1,0 +1,33 @@
+import * as React from "react";
+
+import { PointerEnterExitTrackerContext } from "../pointerEnterExitTrackerContext";
+
+export interface UsePointerEnterExitTrackerResult<T = Element> {
+  onPointerDown: React.PointerEventHandler<T>;
+  onPointerUp: React.PointerEventHandler<T>;
+  onPointerMove: React.PointerEventHandler<T>;
+}
+
+export function usePointerEnterExitTracker<
+  T = Element
+>(): UsePointerEnterExitTrackerResult<T> {
+  const pointerEnterExitTracker = React.useContext(
+    PointerEnterExitTrackerContext
+  );
+
+  const onPointerUpdate: React.PointerEventHandler<T> = (evt) => {
+    if (evt.isPrimary) {
+      pointerEnterExitTracker.updatePointerPosition({
+        left: evt.clientX,
+        top: evt.clientY
+      });
+    }
+  };
+
+  return {
+    onPointerDown: onPointerUpdate,
+    onPointerMove: onPointerUpdate,
+    onPointerUp: () =>
+      pointerEnterExitTracker.updatePointerPosition({ left: -1, top: -1 })
+  };
+}

--- a/src/DragDrop/hooks/usePointerTracker.ts
+++ b/src/DragDrop/hooks/usePointerTracker.ts
@@ -1,0 +1,33 @@
+import { useContext } from "react";
+import { PointerTracker } from "../dragDropController";
+import { DragDropControllerContext } from "../dragDropControllerContext";
+
+export interface UsePointerTrackerResult<T = Element> {
+  onPointerDown: React.PointerEventHandler<T>;
+  onPointerMove: React.PointerEventHandler<T>;
+  onPointerUp: React.PointerEventHandler<T>;
+}
+
+export function usePointerTracker<T = Element>(): UsePointerTrackerResult<T> {
+  // PointerTracker from context
+  const pointerTracker: PointerTracker = useContext(DragDropControllerContext);
+
+  return {
+    onPointerDown: (evt) => {
+      if (evt.isPrimary) {
+        pointerTracker.pointerDown({ left: evt.clientX, top: evt.clientY });
+      }
+    },
+
+    onPointerMove: (evt) => {
+      if (evt.isPrimary) {
+        pointerTracker.pointerMove({ left: evt.clientX, top: evt.clientY });
+      }
+    },
+    onPointerUp: (evt) => {
+      if (evt.isPrimary) {
+        pointerTracker.pointerUp();
+      }
+    }
+  };
+}

--- a/src/DragDrop/pointerEnterExitTracker.ts
+++ b/src/DragDrop/pointerEnterExitTracker.ts
@@ -1,0 +1,82 @@
+export interface Rect {
+  readonly left: number;
+  readonly top: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+export interface Point {
+  readonly left: number;
+  readonly top: number;
+}
+
+export function pointWithinRect(point: Point, rect: Rect): boolean {
+  return (
+    point.left >= rect.left &&
+    point.left < rect.left + rect.width &&
+    point.top >= rect.top &&
+    point.top < rect.top + rect.height
+  );
+}
+
+export interface Surface {
+  getBoundingRect(): Rect;
+  enter(): void;
+  exit(): void;
+}
+
+/** An object to which surfaces can be added. Surfaces receive notification
+ * when a pointer enter/exits its bounding rectangle.
+ */
+export interface PointerEnterExitTracker {
+  addSurface(surface: Surface): void;
+  removeSurface(surface: Surface): void;
+}
+
+/** A receiver of pointer position update notifications */
+export interface PointerPositionSync {
+  updatePointerPosition(position: Point): void;
+}
+
+export class SimplePointerEnterExitTracker
+  implements PointerPositionSync, PointerEnterExitTracker {
+  private readonly surfaces = new Set<Surface>();
+  private surfaceOver: Surface | null = null;
+
+  //#region PointerEnterExitTracker
+  public addSurface(surface: Surface) {
+    this.surfaces.add(surface);
+  }
+
+  public removeSurface(surface: Surface) {
+    if (this.surfaceOver === surface) {
+      this.surfaceOver = null;
+    }
+    this.surfaces.delete(surface);
+  }
+  //#endregion PointerEnterExitTracker
+
+  //#region PointerPositionSync
+  public updatePointerPosition(position: Point) {
+    if (this.surfaceOver) {
+      // Is pointer still over surface?
+      if (pointWithinRect(position, this.surfaceOver.getBoundingRect())) {
+        return;
+      }
+
+      // Point moved outside of surface
+      this.surfaceOver.exit();
+      this.surfaceOver = null;
+    }
+
+    // Check if pointer has entered a new surface
+    for (const surface of this.surfaces) {
+      if (pointWithinRect(position, surface.getBoundingRect())) {
+        this.surfaceOver = surface;
+        surface.enter();
+        return;
+      }
+    }
+  }
+  //#endregion PointerPositionSync
+}

--- a/src/DragDrop/pointerEnterExitTrackerContext.ts
+++ b/src/DragDrop/pointerEnterExitTrackerContext.ts
@@ -1,0 +1,6 @@
+import { createContext } from "react";
+import { SimplePointerEnterExitTracker } from "./pointerEnterExitTracker";
+
+export const PointerEnterExitTrackerContext = createContext<
+  SimplePointerEnterExitTracker
+>(new SimplePointerEnterExitTracker());

--- a/src/DragDrop/pointerEventTypes.ts
+++ b/src/DragDrop/pointerEventTypes.ts
@@ -1,0 +1,12 @@
+export interface PointerEvents<T = Element> {
+  onPointerDown: React.PointerEventHandler<T>;
+  onPointerMove: React.PointerEventHandler<T>;
+  onPointerUp: React.PointerEventHandler<T>;
+  onPointerCancel: React.PointerEventHandler<T>;
+  onPointerOver: React.PointerEventHandler<T>;
+  onPointerOut: React.PointerEventHandler<T>;
+  onPointerEnter: React.PointerEventHandler<T>;
+  onPointerLeave: React.PointerEventHandler<T>;
+}
+
+export type PointerEventKeys = keyof PointerEvents;

--- a/src/Gripper.tsx
+++ b/src/Gripper.tsx
@@ -1,0 +1,23 @@
+export function Gripper({ enabled = true }: { enabled?: boolean }) {
+  return (
+    <div className="Gripper">
+      <svg
+        preserveAspectRatio="none"
+        viewBox="0 0 1 12"
+        style={{
+          visibility: enabled ? "visible" : "hidden",
+          maxWidth: 50,
+          width: "75%",
+          height: 10
+        }}
+      >
+        <rect y="0" width="1" height="1" fill="grey" />
+        <rect y="1" width="1" height="1" fill="lightgrey" />
+        <rect y="4" width="1" height="1" fill="grey" />
+        <rect y="5" width="1" height="1" fill="lightgrey" />
+        <rect y="8" width="1" height="1" fill="grey" />
+        <rect y="9" width="1" height="1" fill="lightgrey" />
+      </svg>
+    </div>
+  );
+}

--- a/src/PlaceSection.tsx
+++ b/src/PlaceSection.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { useDropTarget } from "./DragDrop/hooks/useDropTarget";
 
 import "./styles.css";
 
@@ -18,50 +19,38 @@ export const PlaceSection: React.FunctionComponent<PlaceSectionProps> = ({
   children
 }) => {
   const [isDragOver, setIsDragOver] = React.useState(false);
-  const refDiv = React.useRef<HTMLDivElement>(undefined);
 
-  const handleDragOver = React.useCallback(
-    (ev: React.DragEvent<HTMLDivElement>) => {
-      if (!isValidDropTarget) {
-        ev.dataTransfer.dropEffect = "none";
-      } else {
-        ev.dataTransfer.dropEffect = "move";
-        setIsDragOver(true);
-        if (!isDragOver) {
-          onDragEnter?.();
-        }
-      }
+  const handleDragOver = React.useCallback(() => {
+    setIsDragOver(true);
+    onDragEnter?.();
+  }, [onDragEnter]);
 
-      ev.preventDefault();
-    },
-    [isValidDropTarget, isDragOver, onDragEnter]
-  );
+  const handleDragLeave = React.useCallback(() => {
+    setIsDragOver(false);
+    onDragLeave?.();
+  }, [onDragLeave]);
 
-  const handleDragLeave = React.useCallback(
-    (ev: React.DragEvent<HTMLDivElement>) => {
-      if (ev.target === refDiv.current && isValidDropTarget) {
-        setIsDragOver(false);
-        onDragLeave?.();
-      }
-    },
-    [isValidDropTarget, onDragLeave]
-  );
+  const handleDrop = React.useCallback(() => {
+    setIsDragOver(false);
+    onDragDrop?.();
+  }, [onDragDrop]);
 
-  const handleDragDrop = React.useCallback(() => {
-    if (isValidDropTarget) {
-      setIsDragOver(false);
-      onDragDrop?.();
-    }
-  }, [isValidDropTarget, onDragDrop]);
+  const refElement = React.useRef<HTMLDivElement>(null);
+
+  const dropTargetEvents = useDropTarget({
+    refElement,
+    canDrop: isValidDropTarget,
+    onDropTargetEnter: handleDragOver,
+    onDropTargetLeave: handleDragLeave,
+    onDrop: handleDrop
+  });
 
   return (
     <div
-      ref={refDiv}
+      ref={refElement}
       className="Section"
       style={{ borderColor: isDragOver ? "black" : undefined }}
-      onDragOver={handleDragOver}
-      onDrop={handleDragDrop}
-      onDragLeave={handleDragLeave}
+      {...dropTargetEvents}
     >
       {children}
     </div>

--- a/src/PlaceValuePicture.tsx
+++ b/src/PlaceValuePicture.tsx
@@ -1,5 +1,8 @@
 import * as React from "react";
 import { BrickProps } from "./Brick";
+import { Gripper } from "./Gripper";
+
+import { useDraggable } from "./DragDrop/hooks/useDraggable";
 
 export interface PlaceValueProps {
   value: number;
@@ -22,45 +25,37 @@ export function placeValuePictureFactory(
     onBeginDragItem,
     onEndDrag
   }) => {
-    const [isDraggingGroup, setIsDraggingGroup] = React.useState(false);
-
-    const handleDragStart = React.useCallback(
-      (ev: React.DragEvent<HTMLDivElement>) => {
-        onBeginDragGroup?.();
-        requestAnimationFrame(() => setIsDraggingGroup(true));
-        ev.stopPropagation();
-      },
-      [onBeginDragGroup]
-    );
-
-    const handleDragEnd = React.useCallback(() => {
-      setIsDraggingGroup(false);
-      onEndDrag?.();
-    }, [onEndDrag]);
-
     const isGroupComplete = value >= 10;
+
+    const { dragStyle, dragEvents } = useDraggable({
+      canDrag: isGroupComplete,
+      onBeginDrag: onBeginDragGroup,
+      onEndDrag
+    });
+
     return (
       <div className={outerClass}>
         <div
-          className={`${groupLayoutClass} ${groupContainerClass}${
+          className={`${groupContainerClass}${
             isGroupComplete ? " Complete" : ""
           }`}
-          style={{ visibility: isDraggingGroup ? "hidden" : undefined }}
-          draggable={isGroupComplete}
-          onDragStart={handleDragStart}
-          onDragEnd={handleDragEnd}
+          style={dragStyle}
+          {...dragEvents}
         >
-          {Array.from({ length: 10 })
-            .map((_, i) => i + 1)
-            .map((i) => (
-              <ItemComponent
-                key={i}
-                hide={i > value + previewAdd}
-                ghost={i > value && i <= value + previewAdd}
-                onBeginDrag={onBeginDragItem}
-                onEndDrag={onEndDrag}
-              />
-            ))}
+          <div className={groupLayoutClass}>
+            {Array.from({ length: 10 })
+              .map((_, i) => i + 1)
+              .map((i) => (
+                <ItemComponent
+                  key={i}
+                  hide={i > value + previewAdd}
+                  ghost={i > value && i <= value + previewAdd}
+                  onBeginDrag={onBeginDragItem}
+                  onEndDrag={onEndDrag}
+                />
+              ))}
+          </div>
+          <Gripper enabled={isGroupComplete} />
         </div>
         <div className={`${groupLayoutClass} ${groupContainerClass}`}>
           {Array.from({ length: 10 })

--- a/src/styles.css
+++ b/src/styles.css
@@ -12,6 +12,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  touch-action: none;
 }
 
 .Horizontal {
@@ -106,4 +107,14 @@
   width: var(--tens-brick-height);
   height: var(--tens-brick-height);
   background-color: var(--color-hundreds-brick);
+}
+
+.TensGroup .Gripper {
+  margin-top: 5px;
+  margin-bottom: -12px;
+}
+
+.UnitsGroup .Gripper {
+  margin-top: 5px;
+  margin-bottom: -5px;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,16 @@
+interface Taggable {
+  __tag__?: string;
+}
+
+let nextTag = 1;
+
+export function getTag(thing: unknown): string {
+  const taggable = thing as Taggable;
+
+  if (!taggable.__tag__) {
+    taggable.__tag__ = "T" + nextTag;
+    ++nextTag;
+  }
+
+  return taggable.__tag__;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
         "./src/**/*"
     ],
     "compilerOptions": {
+        "target": "es2015",
         "strict": true,
         "esModuleInterop": true,
         "lib": [


### PR DESCRIPTION
1. Stopped using built-in HTML5 drag/drop behavior and implemented my own drag/drop behavior. This was mainly done to support non-mouse interaction (i.e. touch).

2. Added a gripper to make it easier to pick up the overflow group between positions.