### PR TITLE
Fixed bug where drop target wasn't deactivated when dragging back out.

### DIFF
--- a/src/DragDrop/dragDropController.ts
+++ b/src/DragDrop/dragDropController.ts
@@ -92,7 +92,12 @@ export class DragDropController
     }
   }
 
-  public leaveDrop(me: DropTarget) {}
+  public leaveDrop(me: DropTarget) {
+    if (this.currentDropTarget === me) {
+      me.deactivateDrop();
+      this.currentDropTarget = null;
+    }
+  }
   //#endregion DropController
 
   //#region PointerTracker


### PR DESCRIPTION
I forgot to implement `DropController.leaveDrop(me)`. In fact, I did implement it, but the change never got committed.